### PR TITLE
Fix PARI_FUNC_WRAP

### DIFF
--- a/src/PARIInterface.c
+++ b/src/PARIInterface.c
@@ -515,8 +515,8 @@ static Obj FuncPARI_FUNC_WRAP(Obj self, Obj name, Obj args)
         ErrorQuit("cannot handle functions with %i arguments", narg, 0L);
         break;
     }
-    func = NewFunctionT(T_FUNCTION, sizeof(FuncBag) + sizeof(void *), name,
-                        narg, args, PARI_FUNC_HANDLER2);
+    func = NewFunctionT(T_FUNCTION, sizeof(PariFuncBag), name,
+                        narg, args, handler);
 
     PARI_FUNC(func)->symbol = dlsym(RTLD_LOCAL, CHARS_STRING(name));
 


### PR DESCRIPTION
But note that this code is problematic for other reasons: GAP assumes in various places that function bags come only in two sizes. If you want to use function bags with other sizes, you'll have to update GAP as well.

In GAPJulia we can avoid this by abusing `FEXS_FUNC` to store our pointer; you could also do that.