### PR TITLE
Make BUILD_PARI=yes mode work better on macOS

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -118,7 +118,7 @@ Makefile: configure Makefile.in
 ########################################################################
 ifeq ($(BUILD_PARI),yes)
 PARI_PREFIX := extern/install
-PARI_FILES := $(PARI_PREFIX)/lib/libpari.so
+PARI_FILES := $(PARI_PREFIX)/lib/libpari.*
 PARI_CPPFLAGS = -I $(PARI_PREFIX)/include
 PARI_LDFLAGS = -R $(TOP)/$(PARI_PREFIX)/lib -L$(PARI_PREFIX)/lib -lpari
 


### PR DESCRIPTION
On macOS, the library is called libpari.dylib and not libpari.so. As a
result, typing `make BUILD_PARI=yes` would each time re-configure pari,
and rebuild its documentation.

With this change, `make BUILD_PARI=yes` should work equally well on
Linux and macOS.