### PR TITLE
cleaning and improvements

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -8,10 +8,10 @@
 #
 MODULE_NAME = PARIInterface
 
-SOURCES = src/PARIInterface.c
+SOURCES = src/conversions.c src/functions.c src/PARIInterface.c
 
 TOP = $(shell pwd)
-EXTRA_CPPFLAGS =
+EXTRA_CPPFLAGS = -Isrc/
 EXTRA_LDFLAGS =
 EXTERN_FILES =
 

--- a/gap/PARIInterface.gd
+++ b/gap/PARIInterface.gd
@@ -49,12 +49,3 @@ DeclareGlobalFunction( "PARISetAvma" );
 #! PARI(x^2-1)
 #! @EndExampleSession
 DeclareGlobalFunction( "PARIPolynomial" );
-
-#! @Arguments p
-#! @Description
-#!   Return the (abstract) Galois group of a polynomial
-#! @BeginExampleSession
-#! gap> PARIGaloisGroup(x^3 - x - 1);
-#! [ 6, -1, 1, "S3" ]
-#! @EndExampleSession
-DeclareGlobalFunction( "PARIGaloisGroup" );

--- a/gap/PARIInterface.gi
+++ b/gap/PARIInterface.gi
@@ -50,13 +50,6 @@ function(p)
     return PARI_UNIPOLY(coeffs);
 end );
 
-InstallGlobalFunction( PARIGaloisGroup,
-function(p)
-    local coeffs;
-    coeffs := CoefficientsOfUnivariatePolynomial(p);
-    return PARI_POL_GALOIS_GROUP(coeffs);
-end );
-
 InstallMethod( ViewObj, "for a PARI DatObj",
         [ IsPARIObj ],
 function(o)

--- a/src/PARIInterface.c
+++ b/src/PARIInterface.c
@@ -12,38 +12,13 @@
 
 #define _GNU_SOURCE     // for RTLD_DEFAULT on Linux
 
-#include <pari/pari.h>
-#include "src/compiled.h"          /* GAP headers */
-
-#include <gmp.h>                   /* mp_limb_t :/ */
+#include "PARIInterface.h"
 
 #include <dlfcn.h>
 
-#define PARI_T_GEN 0          // Generic PARI object
-
-#define PARI_DAT_WORDS (sizeof(Obj) * 4)
-#define PARI_DAT_TYPE(obj)         ((Int)(CONST_ADDR_OBJ(obj)[1]))
-#define SET_PARI_DAT_TYPE(obj, t)  (ADDR_OBJ(obj)[1] = (Obj)(t))
-#define PARI_DAT_GEN(obj)          ((GEN)(CONST_ADDR_OBJ(obj)[2]))
-#define SET_PARI_DAT_GEN(obj, g)   (ADDR_OBJ(obj)[2] = (Obj)(g))
-
-static Obj IsPARIObj;
+static Obj IsPARIObj;        // Imported from GAP
 static Obj PARI_GEN_Type;    // Imported from GAP
 static Obj PARI_GEN_REFLIST; // list of references to PARI Objects
-                             // that are still used by GAP
-// Conversions from PARI GEN to corresponding GAP Obj
-static Obj PariGENToObj(GEN v);
-static Obj PariVecToList(GEN v);
-static Obj PariVecSmallToList(GEN v);
-static Obj PariVecToList(GEN v);
-
-// Conversions from GAP Object to PARI GEN
-static GEN ObjToPariGEN(Obj obj);
-static GEN ListToPariVec(Obj list);
-static GEN IntToPariGEN(Obj o);
-
-#define RequirePARIObj(funcname, op)                                             \
-    RequireArgumentCondition(funcname, op, IS_PARI_OBJ(op), "must be a PARI object")
 
 int IS_PARI_OBJ(Obj o)
 {
@@ -67,295 +42,22 @@ Obj NewPARIGEN(GEN data)
     return o;
 }
 
-static Obj FuncPARI_GEN_GET_TYPE(Obj self, Obj obj)
-{
-    if((TNUM_OBJ(obj) != T_DATOBJ) || (PARI_DAT_TYPE(obj) != PARI_T_GEN))
-        ErrorQuit("obj has to be a DATOBJ of type PARI_T_GEN", 0L, 0L);
-    return INTOBJ_INT(typ(PARI_DAT_GEN(obj)));
-}
-
-static Obj FuncPARI_GEN_GET_DATA(Obj self, Obj obj)
-{
-    if((TNUM_OBJ(obj) != T_DATOBJ) || (PARI_DAT_TYPE(obj) != PARI_T_GEN))
-        ErrorQuit("obj has to be a DATOBJ of type PARI_T_GEN", 0L, 0L);
-    return PariGENToObj(PARI_DAT_GEN(obj));
-}
-
-static Obj FuncINT_TO_PARI_GEN(Obj self, Obj obj)
-{
-    return NewPARIGEN(IntToPariGEN(obj));
-}
-
-//
-// Conversions from PARI GEN to corresponding GAP Obj
-//
-static Obj PariVecToList(GEN v)
-{
-    Int len = lg(v);
-    Obj res = NEW_PLIST(T_PLIST, len - 1);
-    SET_LEN_PLIST(res, len - 1);
-
-    for(Int i = 1; i < len; i++) {
-        SET_ELM_PLIST(res, i, PariGENToObj(gel(v, i)));
-        CHANGED_BAG(res);
-    }
-    return res;
-}
-
-static Obj PariVecSmallToList(GEN v)
-{
-    Int len = lg(v);
-    Obj res = NEW_PLIST(T_PLIST, len - 1);
-    SET_LEN_PLIST(res, len - 1);
-
-    for(Int i = 1; i < len; i++) {
-        SET_ELM_PLIST(res, i, ObjInt_Int(v[i]));
-        CHANGED_BAG(res);
-    }
-    return res;
-}
-
-#ifdef PARI_KERNEL_NONE
-static void
-xmpn_mirror(ulong *x, long n)
-{
-  long i;
-  for(i = 0; i < (n>>1); i++)
-  {
-    ulong m=x[i];
-    x[i]=x[n-1-i];
-    x[n-1-i]=m;
-  }
-}
-#define GMP_TO_PARI(a,b) xmpn_mirror(a, b);
-#define PARI_TO_GMP(a,b) xmpn_mirror(a, b);
-#else
-#define GMP_TO_PARI(a,b)
-#define PARI_TO_GMP(a,b)
-#endif
-
-
-static Obj PariIntToIntObj(GEN v)
-{
-    long size;
-    Obj res;
-
-    if (typ (v) != t_INT)
-        ErrorQuit("v has to be a PARI t_INT", 0L, 0L);
-
-    size = signe(v) * (lgefint (v) - 2);
-
-    PARI_TO_GMP(v+2, lgefint (v) - 2)
-
-    res = MakeObjInt((const UInt *)(v+2), size);
-
-    GMP_TO_PARI(v+2, lgefint (v) - 2)
-
-    return res;
-}
-
-static Obj PariFracToRatObj(GEN v)
-{
-    Obj num = PariGENToObj(gel(v, 1));
-    Obj den = PariGENToObj(gel(v, 2));
-
-    if (den == INTOBJ_INT(1))
-        return num;
-
-    Obj res = NewBag(T_RAT, 2 * sizeof(Obj));
-    SET_NUM_RAT(res, PariGENToObj(gel(v, 1)));
-    SET_DEN_RAT(res, PariGENToObj(gel(v, 2)));
-
-    return res;
-}
-
-static Obj PariPolToList(GEN v)
-{
-    Int len = lg(v);
-    Obj res = NEW_PLIST(T_PLIST, len - 2);
-    SET_LEN_PLIST(res, len - 2);
-    for(Int i = 2; i<len; i++) {
-        SET_ELM_PLIST(res, i-1, PariGENToObj(gel(v,i)));
-        CHANGED_BAG(res);
-    }
-    return res;
-}
-
-// Main dispatch
-// When there's no immediately obvious object to convert to
-// We currently convert to a list of subobjects
-// Some of this should probably be done on the GAP Level
-static Obj PariGENToObj(GEN v)
-{
-    Obj res;
-    switch (typ(v)) {
-    case t_INT:       // Integer
-        return PariIntToIntObj(v);
-    case t_COL:       // Column Vector
-    case t_VEC:       // Row Vector
-        return PariVecToList(v);
-    case t_VECSMALL:  // Vector of small integers
-        return PariVecSmallToList(v);
-    case t_STR:       // String
-        return MakeString(GSTR(v));
-    case t_INTMOD:    // Int mod Modulus
-        return PariVecToList(v);
-    case t_FRAC:      // Fraction
-        return PariFracToRatObj(v);
-    case t_POLMOD:    // Polynomial mod modulus
-        return PariVecToList(v);
-    case t_POL:       // Polynomial
-        return PariPolToList(v);
-    case t_MAT:       // Matrix
-        return PariVecToList(v);
-    case t_FFELT:     // Finite field element
-    case t_SER:       // Power series
-    case t_RFRAC:     // Rational function
-    case t_PADIC:     // p-adic numbers
-    case t_QUAD:      // quadratic numbers
-    default:
-        // TODO: Find names for the types
-        ErrorQuit("PariGENToObj: not a supported type %i", typ(v), 0L);
-        break;
-    }
-    return res;
-}
-
-//
-// Converts a GAP Obj to a PARI GEN (if possible)
-//
-
-static GEN Perm2ToPariGEN(Obj perm)
-{
-    UInt deg = DEG_PERM2(perm);
-    const UInt2 * pt = CONST_ADDR_PERM2(perm);
-    GEN  v = cgetg(deg + 1, t_VECSMALL);
-
-    for (UInt i = 1; i <= deg; i++)
-        v[i] = pt[i-1] + 1;
-    return v;
-}
-
-static GEN Perm4ToPariGEN(Obj perm)
-{
-    UInt deg = DEG_PERM4(perm);
-    const UInt4 * pt = CONST_ADDR_PERM4(perm);
-    GEN  v = cgetg(deg + 1, t_VECSMALL);
-
-    for (UInt i = 1; i <= deg; i++)
-        v[i] = pt[i-1] + 1;
-    return v;
-}
-
-static GEN ListToPariVecsmall(Obj list)
-{
-    UInt len = LEN_LIST(list);
-    GEN v = cgetg(len + 1, t_VECSMALL);
-    for(UInt i = 1; i <= len; i++ ) {
-        Obj elt = ELM_LIST(list, i);
-        v[i] = UInt_ObjInt(elt);
-    }
-    return v;
-}
-
-static GEN ListToPariVecVecsmall(Obj list)
-{
-    UInt len = LEN_LIST(list);
-    GEN v = cgetg(len + 1, t_VEC);
-    for(UInt i = 1; i <= len; i++ ) {
-        Obj elt = ELM_LIST(list, i);
-        gel(v, i) = ListToPariVecsmall(elt);
-    }
-    return v;
-}
-
-static GEN ListToPariVecVecVecsmall(Obj list)
-{
-    UInt len = LEN_LIST(list);
-    GEN v = cgetg(len + 1, t_VEC);
-    for(UInt i = 1; i <= len; i++ ) {
-        Obj elt = ELM_LIST(list, i);
-        gel(v, i) = ListToPariVecVecsmall(elt);
-    }
-    return v;
-}
-
-static GEN ListToPariVec(Obj list)
-{
-    UInt len = LEN_LIST(list);
-    GEN v = cgetg(len + 1, t_VEC);
-    for(UInt i = 1; i <= len; i++ ) {
-        Obj elt = ELM_LIST(list, i);
-        gel(v, i) = ObjToPariGEN(elt);
-    }
-    return v;
-}
-
-static GEN IntToPariGEN(Obj o)
-{
-    Int i, size, sign;
-    GEN r;
-
-    if (IS_INTOBJ(o)) {
-        // Immediate integers can be converted using
-        // stoi
-        r = stoi(Int_ObjInt(o));
-    } else { // Large integer
-        size = SIZE_INT(o);
-        sign = IS_POS_INT(o) ? 1 : -1;
-
-        r = cgeti(size + 2);
-        r[1] = evalsigne(sign) | evallgefint(size + 2);
-        memcpy(r+2, ADDR_INT(o), size * sizeof(mp_limb_t));
-        GMP_TO_PARI(r+2, lgefint(r)-2)
-    }
-    return r;
-}
-
-static GEN CoeffListToPariGEN(Obj poly)
-{
-    UInt len;
-    UInt deg;
-    GEN v;
-
-    len = LEN_LIST(poly);
-    // Zero polynomial
-    if (len == 0) {
-        v = cgetg(2, t_POL);
-    } else {
-        deg = len - 1;
-        v = cgetg(3 + deg, t_POL);
-        for(UInt i = 2; i < 2 + len; i++) {
-            Obj elt = ELM_LIST(poly, i - 1);
-            gel(v, i) = IntToPariGEN(elt);
-        }
-    }
-    v[1] = evalsigne(0);
-    v = normalizepol(v);
-
-    return v;
-}
-
-static GEN ObjToPariGEN(Obj obj)
-{
-    if (IS_INT(obj))
-        return IntToPariGEN(obj);
-    else if (IS_PERM2(obj))
-        return Perm2ToPariGEN(obj);
-    else if (IS_PERM4(obj))
-        return Perm4ToPariGEN(obj);
-    else if (IS_LIST(obj))
-        return ListToPariVec(obj);
-    else
-        ErrorQuit("ObjToPariGEN: not a supported type: %s", (Int)TNAM_OBJ(obj), 0L);
-}
-
+/* copied from rationals.c (not public) */
+#define RequireRational(funcname, op)                                        \
+    RequireArgumentCondition(funcname, op,                                   \
+                             TNUM_OBJ(op) == T_RAT || IS_INT(op),            \
+                             "must be a rational")
 
 //
 // GAP Facing functions
 //
 
-Obj FuncPARI_GEN_TO_STR(Obj self, Obj o)
+static Obj FuncPARI(Obj self, Obj o)
+{
+    return NewPARIGEN(ObjToPariGEN(o));
+}
+
+static Obj FuncPARI_GEN_TO_STR(Obj self, Obj o)
 {
   char * str = GENtostr(PARI_DAT_GEN(o));
   Obj s = MakeString(str);
@@ -363,99 +65,31 @@ Obj FuncPARI_GEN_TO_STR(Obj self, Obj o)
   return s;
 }
 
-Obj FuncPARI_VECINT(Obj self, Obj list)
+static Obj FuncPARI_VECINT(Obj self, Obj list)
 {
     GEN v = ListToPariVec(list);
     return NewPARIGEN(v);
 }
 
-Obj FuncPARI_VECVECSMALL(Obj self, Obj list)
+static Obj FuncPARI_VECVECSMALL(Obj self, Obj list)
 {
     GEN v = ListToPariVecVecsmall(list);
     return NewPARIGEN(v);
 }
 
-Obj FuncPARI_VECVECVECSMALL(Obj self, Obj list)
+static Obj FuncPARI_VECVECVECSMALL(Obj self, Obj list)
 {
     GEN v = ListToPariVecVecVecsmall(list);
     return NewPARIGEN(v);
 }
 
-Obj FuncPARI_UNIPOLY(Obj self, Obj poly)
+static Obj FuncPARI_UNIPOLY(Obj self, Obj poly)
 {
     GEN v = CoeffListToPariGEN(poly);
     return NewPARIGEN(v);
 }
 
-Obj FuncPARI_POL_GALOIS_GROUP(Obj self, Obj poly)
-{
-    pari_sp av = avma;
-    GEN v, w;
-    Obj r;
-
-    v = CoeffListToPariGEN(poly);
-    w = polgalois(v, DEFAULTPREC);
-
-    r = PariGENToObj(w);
-    avma = av;
-
-    return r;
-}
-
-Obj FuncPARI_POL_FACTOR_MOD_P(Obj self, Obj poly, Obj p)
-{
-    pari_sp av = avma;
-    GEN v, w, x;
-    Obj r;
-
-    v = CoeffListToPariGEN(poly);
-    x = stoi(Int_ObjInt(p));
-    w = FpX_factor(v, x);
-
-    r = PariGENToObj(w);
-    avma = av;
-
-    return r;
-}
-
-Obj FuncPARI_GEN_ROUNDTRIP(Obj self, Obj x)
-{
-    pari_sp av = avma;
-    Obj r = PariGENToObj(ObjToPariGEN(x));
-    avma = av;
-    return r;
-}
-
-Obj FuncPARI_MULT(Obj self, Obj x, Obj y)
-{
-    pari_sp av = avma;
-    GEN a,b;
-    Obj r;
-
-    a = ObjToPariGEN(x);
-    b = ObjToPariGEN(y);
-
-    r = PariGENToObj(gmul(a,b));
-    avma = av;
-
-    return r;
-}
-
-Obj FuncPARI_FACTOR_INT(Obj self, Obj x)
-{
-    pari_sp av = avma;
-    GEN y, f;
-    Obj r;
-
-    y = ObjToPariGEN(x);
-    f = factorint(y, 0);
-    r = PariGENToObj(f);
-
-    avma = av;
-    return r;
-}
-
-Obj FuncPARI_GET_VERSION(Obj self)
+static Obj FuncPARI_GET_VERSION(Obj self)
 {
     pari_sp av = avma;
     Obj r = PariGENToObj(pari_version());
@@ -463,7 +97,7 @@ Obj FuncPARI_GET_VERSION(Obj self)
     return r;
 }
 
-Obj FuncPARI_INIT(Obj self, Obj stack, Obj stackmax)
+static Obj FuncPARI_INIT(Obj self, Obj stack, Obj stackmax)
 {
     RequireInt("PARI_INIT", stack);
     RequireInt("PARI_INIT", stackmax);
@@ -478,28 +112,36 @@ Obj FuncPARI_INIT(Obj self, Obj stack, Obj stackmax)
     return FuncPARI_GET_VERSION(self);
 }
 
-Obj FuncPARI_CLOSE(Obj self)
+static Obj FuncPARI_GEN_GET_TYPE(Obj self, Obj obj)
+{
+    if((TNUM_OBJ(obj) != T_DATOBJ) || (PARI_DAT_TYPE(obj) != PARI_T_GEN))
+        ErrorQuit("obj has to be a DATOBJ of type PARI_T_GEN", 0L, 0L);
+    return INTOBJ_INT(typ(PARI_DAT_GEN(obj)));
+}
+
+static Obj FuncPARI_GEN_GET_DATA(Obj self, Obj obj)
+{
+    if((TNUM_OBJ(obj) != T_DATOBJ) || (PARI_DAT_TYPE(obj) != PARI_T_GEN))
+        ErrorQuit("obj has to be a DATOBJ of type PARI_T_GEN", 0L, 0L);
+    return PariGENToObj(PARI_DAT_GEN(obj));
+}
+
+static Obj FuncPARI_INT(Obj self, Obj obj)
+{
+    RequireInt("PARI_INT", obj);
+    return NewPARIGEN(IntToPariGEN(obj));
+}
+
+static Obj FuncPARI_FRAC(Obj self, Obj obj)
+{
+    RequireRational("PARI_FRAC", obj);
+    NewPARIGEN(RatToPariGEN(obj));
+}
+
+static Obj FuncPARI_CLOSE(Obj self)
 {
     pari_close();
     return 0;
-}
-
-/* These are good examples of the pattern
-   of calls into PARI from GAP. These functions
-   could be auto-generated */
-
-static Obj FuncPARI_output(Obj self, Obj x)
-{
-    output(PARI_DAT_GEN(x));
-    return 0;
-}
-
-static Obj FuncPARI_gcdii(Obj self, Obj x, Obj y)
-{
-    GEN x_ = PARI_DAT_GEN(x);
-    GEN y_ = PARI_DAT_GEN(y);
-
-    return NewPARIGEN(gcdii(x_, y_));
 }
 
 typedef GEN (* GENFunc) (/*arguments*/);
@@ -685,7 +327,7 @@ static Obj FuncPARI_AVMA(Obj self)
 }
 static void FuncPARI_SET_AVMA(Obj self, Obj av)
 {
-  RequireNonnegativeSmallInt("PARI_SET_AVMA", av); 
+  RequireNonnegativeSmallInt("PARI_SET_AVMA", av);
   avma = UInt_ObjInt(av);
 }
 
@@ -700,21 +342,21 @@ static StructGVarFunc GVarFuncs [] = {
     GVAR_FUNC(PARI_INIT, 2, "stack, stackmax"),
     GVAR_FUNC(PARI_CLOSE, 0, ""),
     GVAR_FUNC(PARI_GET_VERSION, 0, ""),
-    GVAR_FUNC(PARI_GEN_ROUNDTRIP, 1, "x"),
-    GVAR_FUNC(PARI_MULT, 2, "a, b"),
+    /* conversions GAP Obj -> wrapped PARI GEN */
+    GVAR_FUNC(PARI, 1, "o"),
+    GVAR_FUNC(PARI_INT, 1, "i"),
+    GVAR_FUNC(PARI_FRAC, 1, "rat"),
     GVAR_FUNC(PARI_VECINT, 1, "list"),
     GVAR_FUNC(PARI_VECVECSMALL, 1, "list"),
     GVAR_FUNC(PARI_VECVECVECSMALL, 1, "list"),
     GVAR_FUNC(PARI_UNIPOLY, 1, "poly"),
-    GVAR_FUNC(PARI_POL_GALOIS_GROUP, 1, "poly"),
-    GVAR_FUNC(PARI_POL_FACTOR_MOD_P, 2, "poly, p"),
-    GVAR_FUNC(PARI_FACTOR_INT, 1, "x"),
+    /* conversions wrapped PARI GEN -> Gap Obj */
     GVAR_FUNC(PARI_GEN_GET_TYPE, 1, "o"),
     GVAR_FUNC(PARI_GEN_GET_DATA, 1, "o"),
     GVAR_FUNC(PARI_GEN_TO_OBJ, 1, "o"),
-    GVAR_FUNC(INT_TO_PARI_GEN, 1, "i"),
     GVAR_FUNC(PARI_GEN_TO_STR, 1, "o"),
     GVAR_FUNC(PARI_VEC_TO_LIST, 1, "o"),
+    /* function wrapper */
     GVAR_FUNC(PARI_CALL0, 1, "name"),
     GVAR_FUNC(PARI_CALL1, 2, "name, a1"),
     GVAR_FUNC(PARI_CALL2, 3, "name, a1, a2"),

--- a/src/PARIInterface.h
+++ b/src/PARIInterface.h
@@ -1,0 +1,63 @@
+/*
+ * PARIInterface: Interface to PARI
+ *
+ *
+ *  Copyright (C) 2018-2019
+ *    Bill Allombert <bill.allombert@math.u-bordeaux.fr>
+ *    Vincent Delecroix <vincent.delecroix@math.cnrs.fr>
+ *    Markus Pfeiffer <markus.pfeiffer@morphism.de>
+ *
+ * Licensed under the GPL 2 or later.
+ */
+
+#ifndef _PARIInterface_H
+#define _PARIInterface_H
+
+#include <pari/pari.h>
+#include "src/compiled.h"          /* GAP headers */
+
+#include <gmp.h>                   /* mp_limb_t :/ */
+
+#define PARI_T_GEN 0          // Generic PARI object
+
+#define PARI_DAT_WORDS (sizeof(Obj) * 4)
+#define PARI_DAT_TYPE(obj)         ((Int)(CONST_ADDR_OBJ(obj)[1]))
+#define SET_PARI_DAT_TYPE(obj, t)  (ADDR_OBJ(obj)[1] = (Obj)(t))
+#define PARI_DAT_GEN(obj)          ((GEN)(CONST_ADDR_OBJ(obj)[2]))
+#define SET_PARI_DAT_GEN(obj, g)   (ADDR_OBJ(obj)[2] = (Obj)(g))
+
+// Type checking
+int IS_PARI_OBJ(Obj o);
+
+#define RequirePARIObj(funcname, op)                                             \
+    RequireArgumentCondition(funcname, op, IS_PARI_OBJ(op), "must be a PARI object")
+
+// Conversions from PARI GEN to corresponding GAP Obj
+Obj NewPARIGEN(GEN data);      // create a GAP Obj wrapping a GEN
+                               // (no copy)
+
+Obj PariGENToObj(GEN v);       // generic dispatch (C level)
+Obj PariVecToList(GEN v);
+Obj PariVecSmallToList(GEN v);
+Obj PariVecToList(GEN v);
+Obj PariIntToIntObj(GEN v);
+Obj PariFracToRatObj(GEN v);
+Obj PariPolToList(GEN v);
+
+// Conversions from GAP Object to PARI GEN
+GEN ObjToPariGEN(Obj obj);    // generic dispatch (C level)
+GEN ListToPariVec(Obj list);
+GEN IntToPariGEN(Obj o);
+GEN RatToPariGEN(Obj rat);
+GEN ListToPariVecsmall(Obj list);
+GEN ListToPariVecVecsmall(Obj list);
+GEN ListToPariVecVecVecsmall(Obj list);
+GEN CoeffListToPariGEN(Obj poly);
+
+// Some PARI functions
+Obj FuncPARI_output(Obj self, Obj x);
+Obj FuncPARI_gcdii(Obj self, Obj x, Obj y);
+Obj FuncPARI_polgalois(Obj self, Obj poly);
+Obj FuncPARI_POL_FACTOR_MOD_P(Obj self, Obj poly, Obj p);
+
+#endif

--- a/src/conversions.c
+++ b/src/conversions.c
@@ -1,0 +1,305 @@
+/*
+ * PARIInterface: Interface to PARI
+ *
+ *
+ *  Copyright (C) 2018-2019
+ *    Bill Allombert <bill.allombert@math.u-bordeaux.fr>
+ *    Vincent Delecroix <vincent.delecroix@math.cnrs.fr>
+ *    Markus Pfeiffer <markus.pfeiffer@morphism.de>
+ *
+ * Licensed under the GPL 2 or later.
+ */
+
+#define _GNU_SOURCE     // for RTLD_DEFAULT on Linux
+
+#include "PARIInterface.h"
+
+/* TODO */
+/* static Obj FuncPARI_INTMOD(Obj self, ?); */
+/* static Obj FuncPARI_POLMOD(Obj self, ?); */
+
+//
+// Conversions from PARI GEN to GAP Obj
+//
+
+Obj PariVecToList(GEN v)
+{
+    Int len = lg(v);
+    Obj res = NEW_PLIST(T_PLIST, len - 1);
+    SET_LEN_PLIST(res, len - 1);
+
+    for(Int i = 1; i < len; i++) {
+        SET_ELM_PLIST(res, i, PariGENToObj(gel(v, i)));
+        CHANGED_BAG(res);
+    }
+    return res;
+}
+
+Obj PariVecSmallToList(GEN v)
+{
+    Int len = lg(v);
+    Obj res = NEW_PLIST(T_PLIST, len - 1);
+    SET_LEN_PLIST(res, len - 1);
+
+    for(Int i = 1; i < len; i++) {
+        SET_ELM_PLIST(res, i, ObjInt_Int(v[i]));
+        CHANGED_BAG(res);
+    }
+    return res;
+}
+
+#ifdef PARI_KERNEL_NONE
+static void
+xmpn_mirror(ulong *x, long n)
+{
+  long i;
+  for(i = 0; i < (n>>1); i++)
+  {
+    ulong m=x[i];
+    x[i]=x[n-1-i];
+    x[n-1-i]=m;
+  }
+}
+#define GMP_TO_PARI(a,b) xmpn_mirror(a, b);
+#define PARI_TO_GMP(a,b) xmpn_mirror(a, b);
+#else
+#define GMP_TO_PARI(a,b)
+#define PARI_TO_GMP(a,b)
+#endif
+
+
+Obj PariIntToIntObj(GEN v)
+{
+    long size;
+    Obj res;
+
+    if (typ (v) != t_INT)
+        ErrorQuit("v has to be a PARI t_INT", 0L, 0L);
+
+    size = signe(v) * (lgefint (v) - 2);
+
+    PARI_TO_GMP(v+2, lgefint (v) - 2)
+
+    res = MakeObjInt((const UInt *)(v+2), size);
+
+    GMP_TO_PARI(v+2, lgefint (v) - 2)
+
+    return res;
+}
+
+Obj PariFracToRatObj(GEN v)
+{
+    Obj num = PariGENToObj(gel(v, 1));
+    Obj den = PariGENToObj(gel(v, 2));
+
+    if (den == INTOBJ_INT(1))
+        return num;
+
+    Obj res = NewBag(T_RAT, 2 * sizeof(Obj));
+    SET_NUM_RAT(res, PariGENToObj(gel(v, 1)));
+    SET_DEN_RAT(res, PariGENToObj(gel(v, 2)));
+
+    return res;
+}
+
+Obj PariPolToList(GEN v)
+{
+    Int len = lg(v);
+    Obj res = NEW_PLIST(T_PLIST, len - 2);
+    SET_LEN_PLIST(res, len - 2);
+    for(Int i = 2; i<len; i++) {
+        SET_ELM_PLIST(res, i-1, PariGENToObj(gel(v,i)));
+        CHANGED_BAG(res);
+    }
+    return res;
+}
+
+// Main dispatch PARI GEN -> Gap object
+// When there's no immediately obvious object to convert to
+// We currently convert to a list of subobjects
+// Some of this should probably be done on the GAP Level
+Obj PariGENToObj(GEN v)
+{
+    Obj res;
+    switch (typ(v)) {
+    case t_INT:       // Integer
+        return PariIntToIntObj(v);
+    case t_COL:       // Column Vector
+    case t_VEC:       // Row Vector
+        return PariVecToList(v);
+    case t_VECSMALL:  // Vector of small integers
+        return PariVecSmallToList(v);
+    case t_STR:       // String
+        return MakeString(GSTR(v));
+    case t_INTMOD:    // Int mod Modulus
+        return PariVecToList(v);
+    case t_FRAC:      // Fraction
+        return PariFracToRatObj(v);
+    case t_POLMOD:    // Polynomial mod modulus
+        return PariVecToList(v);
+    case t_POL:       // Polynomial
+        return PariPolToList(v);
+    case t_MAT:       // Matrix
+        return PariVecToList(v);
+    case t_FFELT:     // Finite field element
+    case t_SER:       // Power series
+    case t_RFRAC:     // Rational function
+    case t_PADIC:     // p-adic numbers
+    case t_QUAD:      // quadratic numbers
+    default:
+        // TODO: Find names for the types
+        ErrorQuit("PariGENToObj: not a supported type %i", typ(v), 0L);
+        break;
+    }
+    return res;
+}
+
+//
+// Conversions from GAP Obj to PARI GEN
+//
+
+GEN RatToPariGEN(Obj rat)
+{
+    GEN x = cgetg(3, t_FRAC);
+
+    if ( TNUM_OBJ(rat) == T_RAT ) {
+        gel(x, 1) = IntToPariGEN(NUM_RAT(rat));
+        gel(x, 2) = IntToPariGEN(DEN_RAT(rat));
+    }
+    else {
+        gel(x, 1) = IntToPariGEN(rat);
+        gel(x, 2) = stoi(1);
+    }
+
+    return x;
+}
+
+GEN Perm2ToPariGEN(Obj perm)
+{
+    UInt deg = DEG_PERM2(perm);
+    const UInt2 * pt = CONST_ADDR_PERM2(perm);
+    GEN  v = cgetg(deg + 1, t_VECSMALL);
+
+    for (UInt i = 1; i <= deg; i++)
+        v[i] = pt[i-1] + 1;
+    return v;
+}
+
+GEN Perm4ToPariGEN(Obj perm)
+{
+    UInt deg = DEG_PERM4(perm);
+    const UInt4 * pt = CONST_ADDR_PERM4(perm);
+    GEN  v = cgetg(deg + 1, t_VECSMALL);
+
+    for (UInt i = 1; i <= deg; i++)
+        v[i] = pt[i-1] + 1;
+    return v;
+}
+
+GEN ListToPariVecsmall(Obj list)
+{
+    UInt len = LEN_LIST(list);
+    GEN v = cgetg(len + 1, t_VECSMALL);
+    for(UInt i = 1; i <= len; i++ ) {
+        Obj elt = ELM_LIST(list, i);
+        v[i] = UInt_ObjInt(elt);
+    }
+    return v;
+}
+
+GEN ListToPariVecVecsmall(Obj list)
+{
+    UInt len = LEN_LIST(list);
+    GEN v = cgetg(len + 1, t_VEC);
+    for(UInt i = 1; i <= len; i++ ) {
+        Obj elt = ELM_LIST(list, i);
+        gel(v, i) = ListToPariVecsmall(elt);
+    }
+    return v;
+}
+
+GEN ListToPariVecVecVecsmall(Obj list)
+{
+    UInt len = LEN_LIST(list);
+    GEN v = cgetg(len + 1, t_VEC);
+    for(UInt i = 1; i <= len; i++ ) {
+        Obj elt = ELM_LIST(list, i);
+        gel(v, i) = ListToPariVecVecsmall(elt);
+    }
+    return v;
+}
+
+GEN ListToPariVec(Obj list)
+{
+    UInt len = LEN_LIST(list);
+    GEN v = cgetg(len + 1, t_VEC);
+    for(UInt i = 1; i <= len; i++ ) {
+        Obj elt = ELM_LIST(list, i);
+        gel(v, i) = ObjToPariGEN(elt);
+    }
+    return v;
+}
+
+GEN IntToPariGEN(Obj o)
+{
+    Int i, size, sign;
+    GEN r;
+
+    if (IS_INTOBJ(o)) {
+        // Immediate integers can be converted using
+        // stoi
+        r = stoi(Int_ObjInt(o));
+    } else { // Large integer
+        size = SIZE_INT(o);
+        sign = IS_POS_INT(o) ? 1 : -1;
+
+        r = cgeti(size + 2);
+        r[1] = evalsigne(sign) | evallgefint(size + 2);
+        memcpy(r+2, ADDR_INT(o), size * sizeof(mp_limb_t));
+        GMP_TO_PARI(r+2, lgefint(r)-2)
+    }
+    return r;
+}
+
+/* TODO: this only converts *integer* lists to polynomials. We should   */
+/* instead have a converter between GAP and PARI univariate polynomials */
+GEN CoeffListToPariGEN(Obj poly)
+{
+    UInt len;
+    UInt deg;
+    GEN v;
+
+    len = LEN_LIST(poly);
+    // Zero polynomial
+    if (len == 0) {
+        v = cgetg(2, t_POL);
+    } else {
+        deg = len - 1;
+        v = cgetg(3 + deg, t_POL);
+        for(UInt i = 2; i < 2 + len; i++) {
+            Obj elt = ELM_LIST(poly, i - 1);
+            gel(v, i) = IntToPariGEN(elt);
+        }
+    }
+    v[1] = evalsigne(0);
+    v = normalizepol(v);
+
+    return v;
+}
+
+// Main dispatch GAP Obj -> PARI GEN
+GEN ObjToPariGEN(Obj obj)
+{
+    if (IS_INT(obj))
+        return IntToPariGEN(obj);
+    else if (TNUM_OBJ(obj) == T_RAT)
+        return RatToPariGEN(obj);
+    else if (IS_PERM2(obj))
+        return Perm2ToPariGEN(obj);
+    else if (IS_PERM4(obj))
+        return Perm4ToPariGEN(obj);
+    else if (IS_LIST(obj))
+        return ListToPariVec(obj);
+    else
+        ErrorQuit("ObjToPariGEN: not a supported type: %s", (Int)TNAM_OBJ(obj), 0L);
+}

--- a/src/functions.c
+++ b/src/functions.c
@@ -1,0 +1,51 @@
+#include <PARIInterface.h>
+
+/* Two functions returning PARI objects */
+
+Obj FuncPARI_output(Obj self, Obj x)
+{
+    output(PARI_DAT_GEN(x));
+    return 0;
+}
+
+Obj FuncPARI_gcdii(Obj self, Obj x, Obj y)
+{
+    GEN x_ = PARI_DAT_GEN(x);
+    GEN y_ = PARI_DAT_GEN(y);
+
+    return NewPARIGEN(gcdii(x_, y_));
+}
+
+/* Two functions where output are converted back to GAP objects */
+
+Obj FuncPARI_polgalois(Obj self, Obj poly)
+{
+    pari_sp av = avma;
+    GEN v, w;
+    Obj r;
+
+    v = CoeffListToPariGEN(poly);
+    w = polgalois(v, DEFAULTPREC);
+
+    r = PariGENToObj(w);
+    avma = av;
+
+    return r;
+}
+
+Obj FuncPARI_FpX_factor(Obj self, Obj poly, Obj p)
+{
+    pari_sp av = avma;
+    GEN v, w, x;
+    Obj r;
+
+    v = CoeffListToPariGEN(poly);
+    x = stoi(Int_ObjInt(p));
+    w = FpX_factor(v, x);
+
+    r = PariGENToObj(w);
+    avma = av;
+
+    return r;
+}
+

--- a/tst/basic.tst
+++ b/tst/basic.tst
@@ -2,42 +2,28 @@ gap> PARIInitialise();;
 gap> PARI_GEN_TO_OBJ(1);
 Error, GEN_TO_OBJ: <x> must be a PARI object (not the integer 1)
 
-gap> r := PolynomialRing(Integers, 1);;
-gap> p := r.1 ^ 5 + 2;;
-gap> PARIGaloisGroup(p);
-[ 20, -1, 1, "F(5) = 5:4" ]
-
 gap> PARIClose();;
 gap> PARIInitialise(100000,2^24);;
 
-gap> INT_TO_PARI_GEN(4913);
+gap> i := PARI_INT(4913);
 PARI(4913)
-gap> INT_TO_PARI_GEN(3^100);
+gap> PARI_GEN_TO_OBJ(i);
+4913
+gap> i := PARI_INT(3^100);
 PARI(515377520732011331036461129765621272702107522001)
+gap> PARI_GEN_TO_OBJ(i);
+515377520732011331036461129765621272702107522001
+gap> PARI_INT(3/2);
+Error, PARI_INT: <obj> must be an integer (not a rational)
 
-gap> PARI_GEN_ROUNDTRIP((1,3)(2,4,5));
-[ 3, 4, 1, 5, 2 ]
-gap> PARI_GEN_ROUNDTRIP([289, (1,3),(2,4,5)]);
-[ 289, [ 3, 2, 1 ], [ 1, 4, 3, 5, 2 ] ]
-
-gap> PARI_MULT(0,2);
-0
-gap> PARI_MULT(2,0);
-0
-gap> PARI_MULT(2,3);
-6
-gap> PARI_MULT(2^24,3^12);
-8916100448256
-gap> PARI_MULT(2^100,3^200);
-336705732427516898587460627772004697542605295316077247452351004740460372771448563031143507354757009822674618697405379563749376
-
-gap> PARI_FACTOR_INT(24012425);
-[ [ 5, 960497 ], [ 2, 1 ] ]
-gap> PARI_FACTOR_INT(100);
-[ [ 2, 5 ], [ 2, 2 ] ]
-gap> PARI_FACTOR_INT(1204102740127840128401821209348);
-[ [ 2, 3, 163, 7823, 12097, 27719453, 234670785731 ], [ 2, 1, 1, 1, 1, 1, 1 ] 
- ]
+gap> f := PARI_FRAC(2/3);
+PARI(2/3)
+gap> PARI_GEN_TO_OBJ(f);
+2/3
+gap> PARI_FRAC(23);
+PARI(23/1)
+gap> PARI_FRAC(1.23);
+Error, PARI_FRAC: <obj> must be a rational (not a macfloat)
 
 gap> v := PARI_VECINT( [1,2,2^100] );
 PARI([1, 2, 1267650600228229401496703205376])
@@ -59,3 +45,7 @@ gap> PARI_GEN_TO_OBJ(v);
 [ [ [ 1 ], [ 2, 3 ] ], [ [ 4, 5 ] ] ]
 gap> PARI_VECVECVECSMALL( [1] );
 Error, Length: <list> must be a list (not the integer 1)
+
+gap> p := PARI_UNIPOLY([2, 5, 0, 1, 0, 2^100, -3]);
+PARI(-3*x^6 + 1267650600228229401496703205376*x^5 + x^3 + 5*x + 2)
+

--- a/tst/calls.tst
+++ b/tst/calls.tst
@@ -1,36 +1,80 @@
 #
 gap> # TODO: test PARI_CALL0
 
-#
-gap> PARI_CALL1("negi", INT_TO_PARI_GEN(3));
+# PARI_CALL1
+gap> PARI_CALL1("negi", PARI_INT(3));
 PARI(-3)
 gap> negi := PARI_FUNC_WRAP("negi", ["a"]);
 function( a ) ... end
-gap> negi(INT_TO_PARI_GEN(3));
+gap> negi(PARI_INT(3));
 PARI(-3)
 
-#
-gap> PARI_CALL2("gcdii", INT_TO_PARI_GEN(15), INT_TO_PARI_GEN(12));
+gap> PARI_CALL1("polgalois", PARI_UNIPOLY([1, 0, 0, 0, 0, 2]));
+PARI([ 20, -1, 1, "F(5) = 5:4" ])
+
+# PARI_CALL2
+gap> PARI_CALL2("gcdii", PARI_INT(15), PARI_INT(12));
 PARI(3)
 gap> gcdii := PARI_FUNC_WRAP("gcdii", ["x", "y"]);
 function( x, y ) ... end
-gap> gcdii(INT_TO_PARI_GEN(15), INT_TO_PARI_GEN(12));
+gap> gcdii(PARI_INT(15), PARI_INT(12));
 PARI(3)
 
-#
-gap> PARI_CALL3("addmulii", INT_TO_PARI_GEN(1), INT_TO_PARI_GEN(2), INT_TO_PARI_GEN(3));
+gap> PARI_CALL2("FpX_factor", PARI_UNIPOLY([1, 0, 0, -3, 1]), PARI_INT(3));
+PARI([[x^2 + x + 2, x^2 + 2*x + 2]~, Vecsmall([1, 1])])
+
+gap> PARI_CALL2("gmul", PARI_INT(0), PARI_INT(2));
+PARI(0)
+gap> PARI_CALL2("gmul", PARI_INT(2), PARI_INT(0));
+PARI(0)
+gap> PARI_CALL2("gmul", PARI_INT(2), PARI_INT(3));
+PARI(6)
+gap> PARI_CALL2("gmul", PARI_INT(2^24), PARI_INT(3^12));
+PARI(8916100448256)
+gap> PARI_CALL2("gmul", PARI_INT(2^100), PARI_INT(3^200));
+PARI(336705732427516898587460627772004697542605295316077247452351004740460372771448563031143507354757009822674618697405379563749376)
+
+gap> PARI_CALL2("factorint", PARI_INT(24012425), PARI_INT(0));
+PARI(
+[     5 2]
+[960497 1]
+)
+gap> PARI_CALL2("factorint", PARI_INT(100), PARI_INT(0));
+PARI(
+[2 2]
+[5 2]
+)
+gap> PARI_CALL2("factorint", PARI_INT(1204102740127840128401821209348), PARI_INT(0));
+PARI(
+[           2 2]
+
+[           3 1]
+
+[         163 1]
+
+[        7823 1]
+
+[       12097 1]
+
+[    27719453 1]
+
+[234670785731 1]
+)
+
+# PARI_CALL3
+gap> PARI_CALL3("addmulii", PARI_INT(1), PARI_INT(2), PARI_INT(3));
 PARI(7)
 gap> addmulii := PARI_FUNC_WRAP("addmulii", ["x", "y", "z"]);
 function( x, y, z ) ... end
-gap> addmulii(INT_TO_PARI_GEN(1), INT_TO_PARI_GEN(2), INT_TO_PARI_GEN(3));
+gap> addmulii(PARI_INT(1), PARI_INT(2), PARI_INT(3));
 PARI(7)
 
-#
-gap> PARI_CALL4("lincombii", INT_TO_PARI_GEN(1), INT_TO_PARI_GEN(2), INT_TO_PARI_GEN(3), INT_TO_PARI_GEN(4));
+# PARI_CALL4
+gap> PARI_CALL4("lincombii", PARI_INT(1), PARI_INT(2), PARI_INT(3), PARI_INT(4));
 PARI(11)
 gap> lincombii := PARI_FUNC_WRAP("lincombii", ["u", "v", "x", "y"]);
 function( u, v, x, y ) ... end
-gap> lincombii(INT_TO_PARI_GEN(1), INT_TO_PARI_GEN(2), INT_TO_PARI_GEN(3), INT_TO_PARI_GEN(4));
+gap> lincombii(PARI_INT(1), PARI_INT(2), PARI_INT(3), PARI_INT(4));
 PARI(11)
 
 #

--- a/tst/generic.tst
+++ b/tst/generic.tst
@@ -1,0 +1,7 @@
+gap> for a in [23, -5/7, [1,2,3]] do
+>   b := PARI(a);
+>   c := PARI_GEN_TO_OBJ(b);
+>   if c <> a then
+>       Print("wrong", a, c);
+>   fi;
+> od;


### PR DESCRIPTION
- split source files
  - `PARIInterface.c` : exposed functions into GAP
  - `conversions.c` : conversion between PARI `GEN` and GAP `Obj`
  - `functions.c` : PARI function wrappers

- get rid of C wrappers: FuncPARI_POL_GALOIS_GROUP, FuncPARI_POL_FACTOR_MOD_P, FuncPARI_MULT, FuncPARI_FACTOR_INT, FuncPARI_gcdii (in particular fixes https://github.com/gap-packages/PARIInterface/issues/18)

- GAP -> PARI conversions
  - rename `INT_TO_PARI_GEN` -> `PARI_INT`
  - implement `PARI_FRAC`
  - implement a generic `PARI` conversion

- get rid of `PARI_GEN_ROUNDTRIP` (tested more directly in `tst/generic.tst` instead)