### PR TITLE
Use SET_TYPE_OBJ instead of SetTypeDatObj

### DIFF
--- a/src/PARIInterface.c
+++ b/src/PARIInterface.c
@@ -59,7 +59,7 @@ Obj NewPARIGEN(GEN data)
     Obj o;
 
     o = NewBag(T_DATOBJ, PARI_DAT_WORDS);
-    SetTypeDatObj(o, PARI_GEN_Type);
+    SET_TYPE_OBJ(o, PARI_GEN_Type);
     SET_PARI_DAT_TYPE(o, PARI_T_GEN);
     SET_PARI_DAT_GEN(o, data);
     return o;


### PR DESCRIPTION
This amounts to the same, as SET_TYPE_OBJ ends up calling SetTypeDatObj
for a T_DATOBJ. But SetTypeDatObj is only exposed in a header for silly
internal reasons in GAP, and I hope we can undo that eventually. This
means packages should not use it (using SET_TYPE_OBJ will work right
across all GAP versions, too.)